### PR TITLE
feat: Update slicer.org to use updated URL for training site

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       target_source_dir: training-slicer-org
-      slicer_org_sha: 5832583bf58610740f4fe72d273f2887c438fffe
+      slicer_org_sha: a5947e36d740557ddc22d8d3a0a83a536075b418
     steps:
     - name: 📂 setup
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
List of changes:

```
$ git shortlog 5832583..a5947e3 --no-merges
Jean-Christophe Fillion-Robin (1):
      feat: Use updated URL for training site

```