### PR TITLE
fix: Remove ambiguity indicating a given tutorial is based of a specific version

### DIFF
--- a/training.markdown
+++ b/training.markdown
@@ -65,7 +65,7 @@ This page provides hands-on tutorials designed to help users navigate and utiliz
             {% endif %}
           </ul>
           {% if tutorial.details.application_version %}
-          <div>Tutorial based on<i>{{ tutorial.details.application_version }}</i></div>
+          <div>Tutorial based on <i>{{ tutorial.details.application_version }}</i></div>
           {% endif %}
         </div>
         <div class="column">

--- a/training.markdown
+++ b/training.markdown
@@ -65,7 +65,7 @@ This page provides hands-on tutorials designed to help users navigate and utiliz
             {% endif %}
           </ul>
           {% if tutorial.details.application_version %}
-          <div>Tutorial based of <i>{{ tutorial.details.application_version }}</i></div>
+          <div>Tutorial based on<i>{{ tutorial.details.application_version }}</i></div>
           {% endif %}
         </div>
         <div class="column">

--- a/training.markdown
+++ b/training.markdown
@@ -49,9 +49,6 @@ This page provides hands-on tutorials designed to help users navigate and utiliz
             {% if tutorial.details.modules %}
             <li><strong>Modules:</strong> {{ tutorial.details.modules }}</li>
             {% endif %}
-            {% if tutorial.details.application_version %}
-            <li><strong>Application version:</strong> {{ tutorial.details.application_version }}</li>
-            {% endif %}
             {% if tutorial.details.authors %}
             <li><strong>Authors:</strong>
               {% for author in tutorial.details.authors %}
@@ -67,6 +64,9 @@ This page provides hands-on tutorials designed to help users navigate and utiliz
             </li>
             {% endif %}
           </ul>
+          {% if tutorial.details.application_version %}
+          <div>Tutorial based of <i>{{ tutorial.details.application_version }}</i></div>
+          {% endif %}
         </div>
         <div class="column">
           {% if tutorial.image %}


### PR DESCRIPTION
Previous wording seems to imply a given tutorial was only working for a specific application version instead of being created using a specific version.

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/336ee96c-90ad-4fb6-822e-1247a6f1fb04) | ![image](https://github.com/user-attachments/assets/f89ff1db-8aae-4315-b989-9684e037ddec) |
