### PR TITLE
Update tutorials.yml wtih Portuguese and Spanish tutorials

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -15,6 +15,10 @@
       links:
         - label: PDF (English)
           url: https://www.dropbox.com/s/vn8sqlof2kag2kk/SlicerWelcome-tutorial_Slicer4.8_SoniaPujol.pdf
+        - label: PDF (Portuguese)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/Welcome_Pt.pdf
+        - label: PDF (Spanish)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/Welcome_Es.pdf
 
 - id: visualization
   title: Visualization
@@ -34,6 +38,10 @@
           url: https://spujol.github.io/SlicerVisualizationTutorial/SlicerVisualizationTutorial_SoniaPujol.pdf
         - label: PDF (French)
           url: https://spujol.github.io/SlicerVisualizationTutorial/SlicerVisualizationTutorial_SoniaPujol-FrenchVersion.pdf
+        - label: PDF (Portuguese)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/Basics_of_Data_Loading_Pt.pdf
+        - label: PDF (Spanish)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/Basics_of_Data_Loading_Es.pdf
         - label: Website
           url: https://spujol.github.io/SlicerVisualizationTutorial/
 
@@ -72,6 +80,10 @@
           url: https://spujol.github.io/SlicerDICOMTutorial/3DSlicer_DICOMTutorial_SoniaPujol.pdf
         - label: PDF (French)
           url: https://spujol.github.io/SlicerDICOMTutorial/3DSlicer_DICOMTutorial_SoniaPujol-FrenchVersion.pdf
+        - label: PDF (Portuguese)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/DICOM_Pt.pdf
+        - label: PDF (Spanish)
+          url: https://slicerlatinamerica.github.io/media/Tutorials/DICOM_Es.pdf
         - label: Website
           url: https://spujol.github.io/SlicerDICOMTutorial/
 


### PR DESCRIPTION
I am part of the 3D Slicer for Latin America team(led by @spujol ), I saw in the presentation that the tutorials are only available in English and French. I am sending some tutorials in Portuguese and Spanish. We are also translating the remaining to Portuguese and Spanish.
Let me know if I did something wrong.

---------

_Description below updated by @jcfr while reviewing and integrating this pull request._

This pull request adds links to downloading PDFs for Portuguese and Spanish versions of the following tutorials:
* Welcome Tutorial
* Basics of Data Loading and Visualization
* DICOM and Slicer
