### PR TITLE
tutorial: Change video URL in tutorials.yml

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -151,7 +151,7 @@
           url: https://www.cancerimagingarchive.net/collection/tcga-prad/
       links:
         - label: Video (English)
-          url: https://www.youtube.com/watch?v=BJoIexIvtGo
+          url: https://www.youtube.com/watch?v=0at15gjk-Ns
 
     - title: Slicer Segmentation Recipes
       description: Provides step-by-step description of useful segmentation techniques. Segmentation tutorials for common tasks, such as skin surface extraction, craniotomy (splitting segments), sorta segmentation, cerebral vessel segmentation by subtraction, segmentation on arbitrarily oriented slices, skull stripping.


### PR DESCRIPTION
Updated the video URL for the tutorial on femur and pelvis segmenting. It was pointing to the video on heart segmentation.